### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A comprehensive Model Context Protocol (MCP) server that provides access to Google services including Maps, Finance, Flights, Gmail, and Calendar through a unified API.
 
+<a href="https://glama.ai/mcp/servers/@CaptainCrouton89/maps-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CaptainCrouton89/maps-mcp/badge" alt="Server Boilerplate MCP server" />
+</a>
+
 ## Features
 
 ### 🗺️ Google Maps & Places


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Boilerplate](https://glama.ai/mcp/servers/@CaptainCrouton89/maps-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@CaptainCrouton89/maps-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CaptainCrouton89/maps-mcp/badge" alt="Server Boilerplate MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.